### PR TITLE
Port to ghc-events 0.13.0

### DIFF
--- a/hs-speedscope.cabal
+++ b/hs-speedscope.cabal
@@ -32,7 +32,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       base >= 4.12.0.0 && < 5,
-                       ghc-events >= 0.11 && < 0.13,
+                       ghc-events >= 0.13 && < 0.14,
                        aeson                >= 1.4,
                        text                 >= 1.2,
                        vector               >= 0.12,


### PR DESCRIPTION
According to changelog:
```
This is a breaking change. 
Most of the String fields in EventInfo have been replaced with Texts.
```