### PR TITLE
Use machines to decouple filtering and accumulation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,1 @@
 packages: .
-

--- a/hs-speedscope.cabal
+++ b/hs-speedscope.cabal
@@ -37,6 +37,7 @@ library
                        vector               >= 0.12,
                        extra                >= 1.6,
                        optparse-applicative >= 0.15,
+                       machines,
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
This is PoC of using https://github.com/mpickering/eventlog-live/pull/2
though I have inlined the used machines.

This variant of delimit has an additional argument to force pass-through
of some events (used for info events)

cc @mpickering 