### PR TITLE
Abstract the conversion of events into samples

### DIFF
--- a/hs-speedscope.cabal
+++ b/hs-speedscope.cabal
@@ -31,7 +31,7 @@ library
     Speedscope.Schema
   -- other-extensions:
   build-depends:       base >= 4.12.0.0 && < 5,
-                       ghc-events >= 0.13 && < 0.18,
+                       ghc-events >= 0.13 && < 0.20,
                        aeson                >= 1.4,
                        text                 >= 1.2,
                        vector               >= 0.12,

--- a/src/HsSpeedscope.hs
+++ b/src/HsSpeedscope.hs
@@ -6,6 +6,13 @@
 
 module HsSpeedscope (
     entry,
+    convertToSpeedscope,
+    processEventsDefault,
+    isInfoEvent,
+    parseIdent,
+    EventLogProfile(..),
+    CostCentre(..),
+    Sample(..)
 ) where
 
 import Data.String ( fromString )
@@ -61,52 +68,98 @@ entry = do
 run :: SSOptions -> IO ()
 run SSOptions{ file, isolateStart, isolateEnd } = do
   el <- either error id <$> readEventLogFromFile file
-  encodeFile (file ++ ".json") (convertToSpeedscope (isolateStart, isolateEnd ) el)
+  encodeFile (file ++ ".json") (convertToSpeedscope (isolateStart, isolateEnd) isInfoEvent processEventsDefault el)
 
+-- | A Moore machine whose state indicates which delimiting markers have been
+-- seen. If both markers are 'Nothing', then the state will always be 'True'.
+-- If the first marker is given, then the state will always be 'False' until a
+-- value which the marker is a prefix of is seen. If the second marker is given,
+-- then the state will always be 'False' after a value which the marker is a
+-- prefix of is seen.
 markers :: (Maybe Text, Maybe Text) -> Moore Text Bool
-markers (Nothing, Nothing) = m where m = Moore True (const m)
-markers (Just s,  Nothing) = start where
-    start = Moore False $ \s' -> if s == s' then end else start
-    end   = Moore True (const end)
-markers (Nothing, Just e)  = start where
-    start = Moore True $ \e' -> if e == e' then end else start
-    end   = Moore False (const end)
-markers (Just s, Just e) = between s e
+markers (Nothing, Nothing) =
+    go
+  where
+    go = Moore True (const go)
+markers (Just s,  Nothing) =
+    wait_for_start
+  where
+    wait_for_start =
+      Moore False $ \s' ->
+        if s `Data.Text.isPrefixOf` s' then
+          go
+        else
+          wait_for_start
+    go = Moore True (const go)
+markers (Nothing, Just e) =
+    go_until
+  where
+    go_until =
+      Moore True $ \e' ->
+        if e `Data.Text.isPrefixOf` e' then
+          stop
+        else
+          go_until
+    stop = Moore False (const stop)
+markers (Just s, Just e) =
+    go_between
+  where
+    go_between =
+        Moore False wait_for_start
+      where
+        wait_for_start s' = if s `Data.Text.isPrefixOf` s' then go_until else go_between
+    go_until =
+        Moore True close'
+      where
+        close' e' = if e `Data.Text.isPrefixOf` e' then stop else go_until
+    stop = Moore False (const stop)
 
--- | A simple delimiting 'Moore' machine,
--- which is opened by one constant marker and closed by the other one.
-between :: Text -> Text -> Moore Text Bool
-between x y = open where
-    open  = Moore False open' where open' x' = if x == x' then close else open
-    close = Moore True close' where close' y' = if y == y' then end else close
-    end   = Moore False (const end)
-
--- | Delimit the event process.
+-- | Delimit the event process, and only include events which satisfy a
+-- predicate.
 delimit
     :: Monad m
-    => (EventInfo -> Bool)  -- ^ predicate to always pass through events
-    -> Moore Text Bool      -- ^ moore process triggered by markers
+    => (EventInfo -> Bool)
+    -- ^ Only emit events which pass this predicate
+    -> Moore Text Bool
+    -- ^ Only emit events when this 'Moore' process state is 'True'. The process
+    -- will be given the values of 'UserMarker's in the event log.
     -> ProcessT m Event Event
-delimit p = construct . go where
+delimit p =
+    construct . go
+  where
     go :: Monad m => Moore Text Bool -> PlanT (Is Event) Event m ()
     go mm@(Moore s next) = do
-        e <- await
-        case evSpec e of
-            -- on marker step the moore machine.
-            UserMarker m -> do
-                let mm'@(Moore s' _) = next m
-                -- if current or next state is open (== True), emit the marker.
-                when (s || s') $ yield e
-                go mm'
+      e <- await
+      case evSpec e of
+        -- on marker step the moore machine.
+        UserMarker m -> do
+            let mm'@(Moore s' _) = next m
+            -- if current or next state is open (== True), emit the marker.
+            when (s || s') $ yield e
+            go mm'
 
+        -- for other events, emit if the state is open and predicate passes
+        ei -> do
+            when (s || p ei) $ yield e
+            go mm
 
-            -- for other events, emit if the state is open.
-            ei -> do
-                when (s || p ei) $ yield e
-                go mm
-
-convertToSpeedscope :: (Maybe Text, Maybe Text) -> EventLog -> Value
-convertToSpeedscope (is, ie) (EventLog _h (Data (sortOn evTime -> es))) =
+-- | Convert an 'EventLog' into a speedscope profile JSON value. To convert the
+-- event log using the traditional profile extraction logic, use `isInfoEvent`
+-- and `processEventsDefault` for the predicate and processing function,
+-- respectively.
+convertToSpeedscope
+  :: (Maybe Text, Maybe Text)
+  -- ^ Delimiting markers. No events before a user marker containing the first
+  -- string will be included. No events after a user marker containing the
+  -- second string will be included.
+  -> (EventInfo -> Bool)
+  -- ^ Only consider events which satisfy this predicate
+  -> (EventLogProfile -> Event -> EventLogProfile)
+  -- ^ Specifies how to build the profile given the events included based on the
+  -- delimiters and predicate
+  -> EventLog
+  -> Value
+convertToSpeedscope (is, ie) considerEvent processEvents (EventLog _h (Data (sortOn evTime -> es))) =
   case el_version of
     Just (ghc_version, _) | ghc_version < makeVersion [8,9,0]  ->
       error ("Eventlog is from ghc-" ++ showVersion ghc_version ++ " hs-speedscope only works with GHC 8.10 or later")
@@ -120,12 +173,12 @@ convertToSpeedscope (is, ie) (EventLog _h (Data (sortOn evTime -> es))) =
           , exporter           = Just $ fromString version_string
           }
   where
-    Identity (EL (fromMaybe "" -> profile_name) el_version (fromMaybe 1 -> interval) frames samples) =
-        foldlT (flip processEvents) initEL $
+    Identity (EventLogProfile (fromMaybe "" -> profile_name) el_version (fromMaybe 1 -> interval) frames samples) =
+        foldlT processEvents initEL $
             source es ~>
-            delimit isInfoEvent (markers (is, ie))
+            delimit considerEvent (markers (is, ie))
 
-    initEL = EL Nothing Nothing Nothing [] []
+    initEL = EventLogProfile Nothing Nothing Nothing [] []
 
 
     version_string :: String
@@ -152,29 +205,30 @@ convertToSpeedscope (is, ie) (EventLog _h (Data (sortOn evTime -> es))) =
     mkSample (Sample _ti [k]) | fromIntegral k >= num_frames = Nothing
     mkSample (Sample ti ccs) = Just (ti, map (subtract 1 . fromIntegral) (reverse ccs))
 
-    processEvents :: Event -> EL -> EL
-    processEvents (Event _t ei _c) el =
-      case ei of
-        ProgramArgs _ (pname: _args) ->
-          el { prog_name = Just pname }
-        RtsIdentifier _ rts_ident ->
-          el { rts_version = parseIdent rts_ident }
-        ProfBegin ival ->
-          el { prof_interval = Just ival }
-        HeapProfCostCentre n l m s _ ->
-          el { cost_centres = CostCentre n l m s : cost_centres el }
-        ProfSampleCostCentre t _ _ st ->
-          el { el_samples = Sample t (V.toList st) : el_samples el }
-        _ ->
-          el
+-- | Default processing function to convert profiling events into a classic speedscope
+-- profile
+processEventsDefault :: EventLogProfile -> Event -> EventLogProfile
+processEventsDefault elProf (Event _t ei _c) =
+  case ei of
+    ProgramArgs _ (pname: _args) ->
+      elProf { prog_name = Just pname }
+    RtsIdentifier _ rts_ident ->
+      elProf { rts_version = parseIdent rts_ident }
+    ProfBegin ival ->
+      elProf { prof_interval = Just ival }
+    HeapProfCostCentre n l m s _ ->
+      elProf { cost_centres = CostCentre n l m s : cost_centres elProf }
+    ProfSampleCostCentre t _ _ st ->
+      elProf { el_samples = Sample t (V.toList st) : el_samples elProf }
+    _ ->
+      elProf
 
-    isInfoEvent :: EventInfo -> Bool
-    isInfoEvent ProgramArgs {}        = True
-    isInfoEvent RtsIdentifier {}      = True
-    isInfoEvent ProfBegin {}          = True
-    isInfoEvent HeapProfCostCentre {} = True
-    isInfoEvent _ = False
-
+isInfoEvent :: EventInfo -> Bool
+isInfoEvent ProgramArgs {}        = True
+isInfoEvent RtsIdentifier {}      = True
+isInfoEvent ProfBegin {}          = True
+isInfoEvent HeapProfCostCentre {} = True
+isInfoEvent _ = False
 
 mkProfile :: Text -> Word64 -> (Capset, [[Int]]) -> Profile
 mkProfile pname interval (_n, samples) = SampledProfile sampledProfile
@@ -202,13 +256,14 @@ parseIdent s = convert $ listToMaybe $ flip readP_to_S (Data.Text.unpack s) $ do
 
     convert x = (\(a, b) -> (a, Data.Text.pack b)) <$> x
 
-data EL = EL {
-    prog_name :: Maybe Text
-  , rts_version :: Maybe (Version, Text)
-  , prof_interval :: Maybe Word64
-  , cost_centres :: [CostCentre]
-  , el_samples :: [Sample]
-}
+-- | The type we wish to convert event logs into
+data EventLogProfile = EventLogProfile
+    { prog_name :: Maybe Text
+    , rts_version :: Maybe (Version, Text)
+    , prof_interval :: Maybe Word64
+    , cost_centres :: [CostCentre]
+    , el_samples :: [Sample]
+    }
 
 data CostCentre = CostCentre Word32 Text Text Text deriving Show
 


### PR DESCRIPTION
This PR changes the event log conversion to be parameterized by the function used to extract samples from events. This makes it easier to use hs-speedscope as a library for general conversion of event log data into speedscope profiles.

Also updates the bound for ghc-events to < 0.20