### PR TITLE
Fix building with ghc-events-0.20

### DIFF
--- a/src/HsSpeedscope.hs
+++ b/src/HsSpeedscope.hs
@@ -219,7 +219,7 @@ processEventsDefault elProf (Event _t ei _c) =
     HeapProfCostCentre n l m s _ ->
       elProf { cost_centres = CostCentre n l m s : cost_centres elProf }
     ProfSampleCostCentre t _ _ st ->
-      elProf { el_samples = Sample t (V.toList st) : el_samples elProf }
+      elProf { el_samples = Sample (fromIntegral t) (V.toList st) : el_samples elProf }
     _ ->
       elProf
 


### PR DESCRIPTION
ghc-events-0.20 changed the type of profCap from Int32 (CapSet) to Int16 (CapNo). This works around that change by using `fromIntegral` without changing the interface of `hs-speedscope`.
 
Resolves #21 