### PR TITLE
Fix logic for dropping system events

### DIFF
--- a/src/HsSpeedscope.hs
+++ b/src/HsSpeedscope.hs
@@ -200,9 +200,15 @@ convertToSpeedscope (is, ie) considerEvent processEvents (EventLog _h (Data rawE
     mkFrame (CostCentre _n name _m file) = Frame{ name, file = Just file, col = Nothing, line = Nothing }
 
     mkSample :: Sample -> Maybe (Capset, [Int])
-    -- Filter out system frames
-    mkSample (Sample _ti [k]) | fromIntegral k >= num_frames = Nothing
-    mkSample (Sample ti ccs) = Just (ti, map (subtract 1 . fromIntegral) (reverse ccs))
+    mkSample (Sample ti ccs) =
+      if null ccsWithoutSystemFrames then
+        Nothing
+      else
+        Just (ti, map (subtract 1 . fromIntegral) (reverse ccsWithoutSystemFrames))
+      where
+        -- Filter out system frames.
+        -- These often occur at the root, but can sometimes exist inside the stack.
+        ccsWithoutSystemFrames = filter (\k -> fromIntegral k < num_frames) ccs
 
 -- | Default processing function to convert profiling events into a classic speedscope
 -- profile


### PR DESCRIPTION
I occasionally see corrupted .json output that seems to refer to events that are beyond the described frames. This seems to be caused by system CCS occuring deep inside a stack. I'm not sure why this happens.

This commit changes the logic so we consistently drop such entries. We previously only had a special case for dropping stacks where the entire thing consisted of just one system CCS